### PR TITLE
[1.1.0] publish pre-built Docker image and improve configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # UHF Server – Docker Setup
 
+[![Repo](https://img.shields.io/badge/repo-1.1.0-purple.svg)](#changelog)
+[![UHF Server](https://img.shields.io/badge/uhf_server-1.1.0-orange.svg)](#changelog)
+[![Updated](https://img.shields.io/badge/updated-2025--04--21-blue.svg)](#changelog)
+
 Run the [UHF Recording Server](https://www.uhfapp.com/server) using Docker. No manual setup, no system-level dependencies — just `docker compose up`.
 
 ---
@@ -28,13 +32,15 @@ Clone this repo and run:
 ```bash
 git clone https://github.com/solid-pixel/uhf-server-docker
 cd uhf-server-docker
-docker compose up --build -d
+docker compose up -d    # Will automatically pull image from Docker Hub
 ```
 
 Then open UHF, go to the Recordings tab, and add:
 
 - SERVER ADDRESS: `<your-host-ip>`
-- SERVER PORT: `8000` (or the port you set up in `docker-compose.yaml`)
+- SERVER PORT: `8000` (or the port you set up in `docker-compose.yml`)
+
+That's it! No building required. 
 
 ---
 
@@ -42,8 +48,7 @@ Then open UHF, go to the Recordings tab, and add:
 
 ```
 uhf-server-docker/
-├── docker-compose.yml      # Container config
-├── Dockerfile.uhf          # Image build file
+├── docker-compose.yml      # Container config (uses pre-built image)
 └── uhf-data/               # Persistent recordings & database
 ```
 
@@ -54,7 +59,6 @@ uhf-server-docker/
 - **Change port:** edit the `--port` value in `docker-compose.yml`
 - **Change storage path:** adjust the `volumes:` path in `docker-compose.yml`
 - **Auto-start:** enabled via `restart: unless-stopped` in `docker-compose.yml`
-
 
 ---
 
@@ -68,3 +72,18 @@ uhf-server-docker/
 ## License
 
 MIT — do what you want, no warranty
+
+---
+
+## Changelog
+
+<!-- Add your changes below. Most recent at the top. -->
+
+### Version 1.1.0 – 2025-04-21
+#### 🐳 Docker Image Changes
+- Published image to Docker Hub (`solidpixel/uhf-server:1.1.0`)
+
+#### 📝 Repository Changes
+- Added Docker Hub run instructions to README
+- Improved Docker workflow and documentation
+- Restructured README for better clarity

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ MIT — do what you want, no warranty
 
 #### Repository Changes
 - Added Docker Hub run instructions to README
-- Improved Docker workflow and documentation
+- Switched to environment-based configuration (API_HOST, API_PORT, etc.)
+- Improved documentation with customization options
 - Restructured README for better clarity
 </details>
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Run the [UHF Recording Server](https://www.uhfapp.com/server) using Docker. No m
 
 ## ✨ Features
 
-- Fully self-hosted UHF server
+- Fully self-hosted [UHF server](https://github.com/swapplications/uhf-server-dist)
 - Docker + Compose setup (no system install required)
 - `unzip` and `ffmpeg` bundled in
 - Persistent volume for recordings

--- a/README.md
+++ b/README.md
@@ -56,9 +56,17 @@ uhf-server-docker/
 
 ## ⚙️ Customization
 
-- **Change port:** edit the `--port` value in `docker-compose.yml`
-- **Change storage path:** adjust the `volumes:` path in `docker-compose.yml`
-- **Auto-start:** enabled via `restart: unless-stopped` in `docker-compose.yml`
+The following environment variables can be configured in `docker-compose.yml`:
+
+- **API_HOST**: Server listen address (default: `0.0.0.0`)
+- **API_PORT**: Server port (default: `8000`)
+- **RECORDINGS_DIR**: Path to recordings inside container (default: `/var/lib/uhf-server/recordings`)
+- **DB_PATH**: Path to database file inside container (default: `/var/lib/uhf-server/db.json`)
+- **LOG_LEVEL**: Logging verbosity (default: `INFO`)
+
+You can also customize:
+- **Storage location:** adjust the `volumes:` path in `docker-compose.yml`
+- **Auto-restart:** enabled via `restart: unless-stopped` in `docker-compose.yml`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -87,3 +87,7 @@ MIT — do what you want, no warranty
 - Added Docker Hub run instructions to README
 - Improved Docker workflow and documentation
 - Restructured README for better clarity
+
+### Version 1.0.0
+Initial release
+

--- a/README.md
+++ b/README.md
@@ -79,15 +79,20 @@ MIT — do what you want, no warranty
 
 <!-- Add your changes below. Most recent at the top. -->
 
-### Version 1.1.0 – 2025-04-21
-#### 🐳 Docker Image Changes
+<details open>
+<summary><strong>Version 1.1.0</strong> – 2025-04-21</summary>
+
+#### Docker Image Changes
 - Published image to Docker Hub (`solidpixel/uhf-server:1.1.0`)
 
-#### 📝 Repository Changes
+#### Repository Changes
 - Added Docker Hub run instructions to README
 - Improved Docker workflow and documentation
 - Restructured README for better clarity
+</details>
 
-### Version 1.0.0
+<details>
+<summary><strong>Version 1.0.0</strong></summary>
+
 Initial release
-
+</details>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Run the [UHF Recording Server](https://www.uhfapp.com/server) using Docker. No m
 
 ---
 
-## Features
+## ✨ Features
 
 - Fully self-hosted UHF server
 - Docker + Compose setup (no system install required)
@@ -18,14 +18,14 @@ Run the [UHF Recording Server](https://www.uhfapp.com/server) using Docker. No m
 
 ---
 
-## Requirements
+## 📋 Requirements
 
 - Docker
 - Docker Compose v2+
 
 ---
 
-## Getting Started
+## 🚀 Getting Started
 
 Clone this repo and run:
 
@@ -44,7 +44,7 @@ That's it! No building required.
 
 ---
 
-## Folder Structure
+## 📁 Folder Structure
 
 ```
 uhf-server-docker/
@@ -54,7 +54,7 @@ uhf-server-docker/
 
 ---
 
-## Customization
+## ⚙️ Customization
 
 - **Change port:** edit the `--port` value in `docker-compose.yml`
 - **Change storage path:** adjust the `volumes:` path in `docker-compose.yml`
@@ -62,20 +62,20 @@ uhf-server-docker/
 
 ---
 
-## Credits
+## 👥 Credits
 
 - [UHF Server](https://www.uhfapp.com) by Swapplications
 - Docker wrapper by [Alessandro Benassi](https://github.com/solid-pixel)
 
 ---
 
-## License
+## 📜 License
 
 MIT — do what you want, no warranty
 
 ---
 
-## Changelog
+## 📝 Changelog
 
 <!-- Add your changes below. Most recent at the top. -->
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # UHF Server – Docker Setup
 
 [![Repo](https://img.shields.io/badge/repo-1.1.0-purple.svg)](#changelog)
-[![UHF Server](https://img.shields.io/badge/uhf_server-1.1.0-orange.svg)](#changelog)
+[![UHF Server](https://img.shields.io/badge/uhf_server-1.1.0-orange.svg)](https://github.com/swapplications/uhf-server-dist)
 [![Updated](https://img.shields.io/badge/updated-2025--04--21-blue.svg)](#changelog)
 
 Run the [UHF Recording Server](https://www.uhfapp.com/server) using Docker. No manual setup, no system-level dependencies — just `docker compose up`.
@@ -10,11 +10,11 @@ Run the [UHF Recording Server](https://www.uhfapp.com/server) using Docker. No m
 
 ## ✨ Features
 
-- Fully self-hosted [UHF server](https://github.com/swapplications/uhf-server-dist)
+- Fully self-hosted UHF server
+- `uhf-server` script bundled in (https://github.com/swapplications/uhf-server-dist)
 - Docker + Compose setup (no system install required)
 - `unzip` and `ffmpeg` bundled in
 - Persistent volume for recordings
-- Works on any Linux machine (x86_64)
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,4 @@ services:
       - RECORDINGS_DIR=/var/lib/uhf-server/recordings
       - DB_PATH=/var/lib/uhf-server/db.json
       - LOG_LEVEL=INFO
+    command: ["uhf-server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,9 @@ services:
       - ./uhf-data:/var/lib/uhf-server
     working_dir: /uhf-data
     network_mode: host
-    command: ["uhf-server", "--port", "8000"] # optionally change the port in case it's already in use by something else
+    environment:
+      - API_HOST=0.0.0.0
+      - API_PORT=8000
+      - RECORDINGS_DIR=/var/lib/uhf-server/recordings
+      - DB_PATH=/var/lib/uhf-server/db.json
+      - LOG_LEVEL=INFO

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,7 @@ version: '3.8'
 
 services:
   uhf-server:
-    build:
-      context: .
-      dockerfile: Dockerfile.uhf
+    image: solidpixel/uhf-server:1.1.0
     container_name: uhf-server
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
# v1.1.0

#### Docker Image Changes
- Published image to Docker Hub (`solidpixel/uhf-server:1.1.0`)

#### Repository Changes
- Added Docker Hub run instructions to README
- Switched to environment-based configuration (API_HOST, API_PORT, etc.)
- Improved documentation with customization options
- Restructured README for better clarity