### PR TITLE
[1.2.2] Improve Docker workflow and use latest tag [skip_build]

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,26 @@ permissions:
   contents: write
 
 jobs:
+  check_pr:
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+    runs-on: ubuntu-latest
+    outputs:
+      skip_build: ${{ steps.pr_info.outputs.skip_build }}
+    steps:
+      - name: Get PR info
+        id: pr_info
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_TITLE=$(gh api /repos/${{ github.repository }}/commits/${{ github.sha }}/pulls --jq '.[0].title')
+          if [[ "$PR_TITLE" == *"[skip_build]"* ]]; then
+            echo "skip_build=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip_build=false" >> $GITHUB_OUTPUT
+          fi
+
   tag:
+    needs: check_pr
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
     runs-on: ubuntu-latest
     outputs:
@@ -41,10 +60,11 @@ jobs:
           fi
 
   docker:
-    needs: tag
+    needs: [check_pr, tag]
     if: |
-      !contains(github.event.pull_request.title, '[skip_build]') &&
-      (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'))
+      needs.check_pr.outputs.skip_build != 'true' &&
+      github.event_name == 'push' && 
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UHF Server – Docker Setup
 
-[![Repo](https://img.shields.io/badge/repo-1.2.1-purple.svg)](#changelog)
+[![Repo](https://img.shields.io/badge/repo-1.2.2-purple.svg)](#changelog)
 [![UHF Server](https://img.shields.io/badge/uhf_server-1.2.0-orange.svg)](https://github.com/swapplications/uhf-server-dist)
 [![Updated](https://img.shields.io/badge/updated-2025--04--22-blue.svg)](#changelog)
 
@@ -89,6 +89,13 @@ MIT — do what you want, no warranty
 <!-- Add your changes below. Most recent at the top. -->
 
 <details open>
+<summary><strong>Version 1.2.2</strong> – 2025-04-22</summary>
+
+#### Repository Changes
+- Fixed GitHub Actions workflow for automated releases
+</details>
+
+<details>
 <summary><strong>Version 1.2.1</strong> – 2025-04-22</summary>
 
 #### Repository Changes


### PR DESCRIPTION
## Changes

### Docker Changes
- Updated docker-compose.yml to use 'latest' tag
- Users will now automatically get the newest version

### Workflow Improvements
- Split workflow into separate tag and build jobs
- Added PR title check for [skip_build] that works after merge
- Fixed tag creation to only run on merge to main

### Documentation
- Added changelog entries for 1.2.1 and 1.2.2
- Updated version badges

### Version Updates
- 1.2.2: Fixed GitHub Actions workflow
- 1.2.1: Updated to use latest tag in docker-compose.yml