### PR TITLE
[1.2.5] chore: compose healthcheck & improve comments, revisioned image tag, scripts & docs updates

### DIFF
--- a/.dev/build-docker.sh
+++ b/.dev/build-docker.sh
@@ -11,33 +11,49 @@ NC='\033[0m' # No Color
 # Load versions
 source "$(dirname "$0")/versions.env"
 
+# Build image tag
+if [ -n "$DOCKER_REVISION" ]; then
+    IMAGE_TAG="uhf-${UHF_VERSION}-ffmpeg${FFMPEG_VERSION}-${DOCKER_REVISION}"
+else
+    IMAGE_TAG="uhf-${UHF_VERSION}-ffmpeg${FFMPEG_VERSION}"
+fi
+
 # Build and push multi-arch image
-echo -e "\n${BLUE}🏗️  Building for ${YELLOW}amd64, arm64${BLUE} with version ${YELLOW}${UHF_VERSION}-ffmpeg${FFMPEG_VERSION}${NC}..."
+echo -e "\n${BLUE}🏗️  Building for ${YELLOW}amd64, arm64${BLUE} with version ${YELLOW}${IMAGE_TAG}${NC}..."
 
 docker buildx build \
     --platform linux/amd64,linux/arm64 \
     --build-arg UHF_VERSION="${UHF_VERSION}" \
     -f Dockerfile.uhf \
-    -t "solidpixel/uhf-server:${UHF_VERSION}-ffmpeg${FFMPEG_VERSION}" \
+    -t "solidpixel/uhf-server:${IMAGE_TAG}" \
     -t "solidpixel/uhf-server:latest" \
-    --push \
     .
 
+# Prompt to push images
+read -p "$(echo -e ${BLUE}Push images to Docker Hub? [y/N]${NC}) " -n1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    echo -e "\n${BLUE}🚀 Pushing images...${NC}"
+    docker push "solidpixel/uhf-server:${IMAGE_TAG}"
+    docker push "solidpixel/uhf-server:latest"
+    echo -e "${GREEN}✅ Push complete!${NC}\n"
+fi
+
 echo -e "\n${GREEN}✨ Done! Docker images:${NC}"
-echo -e "${BLUE}📦 solidpixel/uhf-server:${YELLOW}${UHF_VERSION}-ffmpeg${FFMPEG_VERSION}${NC}"
+echo -e "${BLUE}📦 solidpixel/uhf-server:${YELLOW}${IMAGE_TAG}${NC}"
 echo -e "${BLUE}📦 solidpixel/uhf-server:${YELLOW}latest${NC}\n"
 
 # Ask to clean up local images
 echo -e "${BLUE}🧹 Clean up local images?${NC}"
 echo -e "${YELLOW}This will remove the following images from your laptop:${NC}"
-echo -e "  ${BLUE}• solidpixel/uhf-server:${YELLOW}${UHF_VERSION}-ffmpeg${FFMPEG_VERSION}${NC}"
+echo -e "  ${BLUE}• solidpixel/uhf-server:${YELLOW}${IMAGE_TAG}${NC}"
 echo -e "  ${BLUE}• solidpixel/uhf-server:${YELLOW}latest${NC}"
 read -p "$(echo -e ${BLUE}Delete these images? [y/N]${NC} )" -n 1 -r
 echo
 
 if [[ $REPLY =~ ^[Yy]$ ]]; then
     echo -e "\n${BLUE}🗑️  Removing local images...${NC}"
-    docker rmi "solidpixel/uhf-server:${UHF_VERSION}-ffmpeg${FFMPEG_VERSION}" "solidpixel/uhf-server:latest" 2>/dev/null || true
+    docker rmi "solidpixel/uhf-server:${IMAGE_TAG}" "solidpixel/uhf-server:latest" 2>/dev/null || true
     echo -e "${GREEN}✨ Cleanup complete!${NC}\n"
 else
     echo -e "\n${BLUE}ℹ️  Keeping local images${NC}\n"

--- a/.dev/release.sh
+++ b/.dev/release.sh
@@ -11,8 +11,12 @@ NC='\033[0m' # No Color
 # Source versions
 source "$(dirname "$0")/versions.env"
 
-# Generate Docker image version
-DOCKER_VERSION="${UHF_VERSION}-ffmpeg${FFMPEG_VERSION}"
+# Generate Docker image version (includes optional patch revision)
+if [ -n "$DOCKER_REVISION" ]; then
+    DOCKER_VERSION="uhf-${UHF_VERSION}-ffmpeg${FFMPEG_VERSION}-${DOCKER_REVISION}"
+else
+    DOCKER_VERSION="uhf-${UHF_VERSION}-ffmpeg${FFMPEG_VERSION}"
+fi
 
 # Path to files
 README_PATH="$(dirname "$0")/../README.md"

--- a/.dev/versions.env
+++ b/.dev/versions.env
@@ -1,8 +1,17 @@
 # Version definitions for UHF Server Docker
-REPO_VERSION=1.2.4
+
+# Tag of this repo itself (e.g. config/scripts/compose changes)
+REPO_VERSION=1.2.5
+
+# The actual UHF version used inside the image
 UHF_VERSION=1.2.0
+
+# FFmpeg version used as base
 FFMPEG_VERSION=7.0.2
 
-# Docker image version is generated from UHF_VERSION and FFMPEG_VERSION
-# Format: ${UHF_VERSION}-ffmpeg${FFMPEG_VERSION}
-# Example: 1.2.0-ffmpeg7.0.2
+# Optional Docker-level patch version (use d1, d2, etc to track image-only changes)
+DOCKER_REVISION=d2
+
+# Docker image version is generated from UHF_VERSION, FFMPEG_VERSION, and optional DOCKER_REVISION
+# Format: uhf-${UHF_VERSION}-ffmpeg${FFMPEG_VERSION}-${DOCKER_REVISION}
+# Example: uhf-1.2.0-ffmpeg7.0.2-d2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Changelog
 
 <!-- Add your changes below. Most recent at the top. -->
+## Version 1.2.5 – 2025-04-25
+
+#### Docker Compose Changes
+- Moved healthcheck from Dockerfile into `docker-compose.yml` (monitored via `/server/stats` every 30s)
+- Added optional recordings override volume (`./uhf-recordings:/var/lib/uhf-server/recordings`)
+- Added comments to `docker-compose.yml` for better onboarding
+
+#### Docker Image Changes
+- New Docker image tag: `solidpixel/uhf-server:uhf-1.2.0-ffmpeg7.0.2-d2`
+- Removed healthcheck from Dockerfile (now in `docker-compose.yml`)
+
+#### Dev Changes
+- Dev: Support optional `DOCKER_REVISION` for patch-level image tags in `.dev/versions.env`
+- Dev: Updated `build-docker.sh` and `release.sh` to include `DOCKER_REVISION` in image versioning
+
+#### Documentation Changes
+- Updated README with optional recordings mount and healthcheck details
+- build-docker.sh now prompts to push images after build
+
 ## Version 1.2.4 – 2025-04-24
 
 #### Internal Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ The scripts handle different aspects of the release:
 
 The Docker images will be pushed to Docker Hub with these tags:
 - `solidpixel/uhf-server:latest`
-- `solidpixel/uhf-server:<UHF_VERSION>-ffmpeg<FFMPEG_VERSION>`
+- `solidpixel/uhf-server:<IMAGE_TAG>` (version tag including optional `-DOCKER_REVISION`, e.g. `uhf-1.2.0-ffmpeg7.0.2-d2`)
 
 ## Pull Request Guidelines
 

--- a/Dockerfile.uhf
+++ b/Dockerfile.uhf
@@ -68,9 +68,5 @@ RUN mkdir -p /var/lib/uhf-server/recordings
 # Set working directory
 WORKDIR /var/lib/uhf-server
 
-# Add healthcheck
-HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
-    CMD curl -f "http://localhost:8000/server/stats" || exit 1
-
 # Start UHF server
 CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # UHF Server – Docker Setup
 
-[![Repo](https://img.shields.io/badge/repo-1.2.4-purple.svg)](CHANGELOG.md)
+[![Repo](https://img.shields.io/badge/repo-1.2.5-purple.svg)](CHANGELOG.md)
 [![UHF Server](https://img.shields.io/badge/uhf_server-1.2.0-orange.svg)](https://github.com/swapplications/uhf-server-dist)
 [![FFmpeg](https://img.shields.io/badge/ffmpeg-7.0.2-green.svg)](https://ffmpeg.org/)
-[![Updated](https://img.shields.io/badge/updated-2025--04--23-blue.svg)](CHANGELOG.md)
+[![Docker](https://img.shields.io/badge/Docker-uhf--1.2.0--ffmpeg7.0.2--d2-blue?logo=docker)](https://hub.docker.com/r/solidpixel/uhf-server/tags)
 
 Run the [UHF Recording Server](https://www.uhfapp.com/server) using Docker. No manual setup, no system-level dependencies — just `docker compose up` and visit port 8000 (or your custom port).
 
@@ -71,6 +71,7 @@ You can also customize:
 - **Port mapping:** change `8000:8000` to `YOUR_PORT:8000` in `docker-compose.yml` to use a different external port
 - **Auto-restart:** enabled via `restart: unless-stopped` in `docker-compose.yml`
 - **Health checks:** container health is monitored every 30s via `/server/stats` endpoint
+- **Recordings folder:** override only the recordings directory by uncommenting `./uhf-recordings:/var/lib/uhf-server/recordings` in `docker-compose.yml` (optional; in addition to the main data mount)
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,41 @@
 version: '3.8'
 
 services:
+
   uhf-server:
-    image: solidpixel/uhf-server:1.2.0-ffmpeg7.0.2
+
+    image: solidpixel/uhf-server:uhf-1.2.0-ffmpeg7.0.2-d2
     container_name: uhf-server
     restart: unless-stopped
-    volumes:
-      - ./uhf-data:/var/lib/uhf-server
-    ports:
-      - 8000:8000 # host:container
 
-    # Optional environment variables:
-    # Uncomment to override defaults
+    volumes:
+      # Persist both recordings (uhf-server/recordings) and database (uhf-server/db.json) by mounting the full data directory:
+      - ./uhf-data:/var/lib/uhf-server
+
+      # OPTIONAL: store recordings in a different location
+      # Uncomment the line below IN ADDITION to the one above.
+      # This will override only the /recordings folder inside the container:
+      # - ./uhf-recordings:/var/lib/uhf-server/recordings
+
+    ports:
+      - 8000:8000 # <HOST>:<CONTAINER>
+                  # <HOST> is what you set in UHF settings. 
+                  # <CONTAINER> must match API_PORT (default is 8000)
+
+    # Optional container environment config:
+    # Uncomment to customize internal container settings (usually not needed)
     # environment:
-    #   - API_HOST=0.0.0.0          # bind to all interfaces
-    #   - API_PORT=8000             # default API port - changing this might break healthchecks
-    #   - RECORDINGS_DIR=/var/lib/uhf-server/recordings  # location for recordings
-    #   - DB_PATH=/var/lib/uhf-server/db.json            # path to database file
-    #   - LOG_LEVEL=INFO            # (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+    #   - API_HOST=0.0.0.0
+    #   - API_PORT=8000
+    #   - RECORDINGS_DIR=/var/lib/uhf-server/recordings
+    #   - DB_PATH=/var/lib/uhf-server/db.json
+    #   - LOG_LEVEL=INFO  # Options: DEBUG, INFO, WARNING, ERROR, CRITICAL
 
     command: ["uhf-server"]
+
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/server/stats"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      # ⚠️ If you change API_PORT from 8000, you must update the healthcheck URL.


### PR DESCRIPTION
This PR prepares the v1.2.5 release:

- Docker Compose: moved healthcheck into `docker-compose.yml`, added recordings mount comments
- Docker Image: added support for `DOCKER_REVISION` and updated image tag to `uhf-1.2.0-ffmpeg7.0.2-d2`
- Scripts: `build-docker.sh` now prompts for push; `release.sh` and badges updated to handle revisioned tags
- Documentation: README, CHANGELOG, CONTRIBUTING updated to reflect new flow and version tags

Please review and merge to cut the v1.2.5 release.