### PR TITLE
[1.2.6] build: bump ffmpeg to 7.1.1 and switch image to Ubuntu 25.04

### DIFF
--- a/.dev/build-docker.sh
+++ b/.dev/build-docker.sh
@@ -27,13 +27,15 @@ docker buildx inspect --bootstrap
 
 # Build multi-arch image
 docker buildx build \
+    --pull \
+    --no-cache \
     --platform linux/amd64,linux/arm64 \
     --build-arg UHF_VERSION="${UHF_VERSION}" \
-    -f Dockerfile.uhf \
+    -f ./Dockerfile.uhf \
     -t "solidpixel/uhf-server:${IMAGE_TAG}" \
     -t "solidpixel/uhf-server:latest" \
     --push \
-    .
+    ..
 
 echo -e "\n${GREEN}✨ Done! Docker images:${NC}"
 echo -e "${BLUE}📦 solidpixel/uhf-server:${YELLOW}${IMAGE_TAG}${NC}"

--- a/.dev/versions.env
+++ b/.dev/versions.env
@@ -1,16 +1,16 @@
 # Version definitions for UHF Server Docker
 
 # Tag of this repo itself (e.g. config/scripts/compose changes)
-REPO_VERSION=1.2.5
+REPO_VERSION=1.2.6
 
 # The actual UHF version used inside the image
 UHF_VERSION=1.2.0
 
 # FFmpeg version used as base
-FFMPEG_VERSION=7.0.2
+FFMPEG_VERSION=7.1.1
 
 # Optional Docker-level patch version (use d1, d2, etc to track image-only changes)
-DOCKER_REVISION=d2
+DOCKER_REVISION=d1
 
 # Docker image version is generated from UHF_VERSION, FFMPEG_VERSION, and optional DOCKER_REVISION
 # Format: uhf-${UHF_VERSION}-ffmpeg${FFMPEG_VERSION}-${DOCKER_REVISION}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Version 1.2.6 – 2025-04-29
 
 #### Docker Compose Changes
-- Update version numbers in .dev/versions.env to `1.2.6`, `7.1.1`, `d1`
+- Update `image` tag to `solidpixel/uhf-server:uhf-1.2.0-ffmpeg7.1.1-d1`
 
 #### Docker Image Changes
 - New Docker image tag: `solidpixel/uhf-server:uhf-1.2.0-ffmpeg7.1.1-d1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 <!-- Add your changes below. Most recent at the top. -->
 
+## Version 1.2.6 – 2025-04-29
+
+#### Docker Compose Changes
+- Update version numbers in .dev/versions.env to `1.2.6`, `7.1.1`, `d1`
+
+#### Docker Image Changes
+- New Docker image tag: `solidpixel/uhf-server:uhf-1.2.0-ffmpeg7.1.1-d1`
+- Updated FFmpeg to standard version `7.1.1` (previously used custom build)
+- Switched to `Ubuntu 25.04` (previously used `Debian Bookworm`)
+
 ## Version 1.2.5 – 2025-04-25
 
 #### Docker Compose Changes
@@ -79,4 +89,3 @@
 ## Version 1.0.0
 
 Initial release
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,4 +93,3 @@ Feel free to open an issue for:
 - Feature requests
 - Questions about the codebase
 - Documentation improvements
-

--- a/Dockerfile.uhf
+++ b/Dockerfile.uhf
@@ -1,36 +1,8 @@
-FROM debian:bookworm-slim
+# Final image on Ubuntu 25.04
+FROM ubuntu:25.04
 
-# Install dependencies for FFmpeg and UHF server
-RUN apt-get update && apt-get install -y \
-    autoconf automake build-essential cmake git libtool pkg-config \
-    libass-dev libfreetype6-dev libgnutls28-dev libsdl2-dev \
-    libva-dev libvdpau-dev libvorbis-dev libxcb1-dev \
-    libxcb-shm0-dev libxcb-xfixes0-dev meson ninja-build \
-    texinfo wget yasm zlib1g-dev libx264-dev libx265-dev \
-    python3 python3-pip python3-venv curl bash unzip \
-    && rm -rf /var/lib/apt/lists/*
-
-# Build FFmpeg 7 from source
-RUN cd /usr/local/src \
-    && git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg \
-    && cd ffmpeg \
-    && git checkout n7.0.2 \
-    && ./configure \
-        --prefix=/usr/local \
-        --enable-gpl \
-        --enable-nonfree \
-        --enable-libx264 \
-        --enable-libx265 \
-        --enable-shared \
-    && make -j"$(nproc)" \
-    && make install \
-    && ldconfig \
-    && cd / \
-    && rm -rf /usr/local/src/ffmpeg
-
-# Make FFmpeg 7 the default
-RUN mv /usr/bin/ffmpeg /usr/bin/ffmpeg.bak || true \
-    && ln -s /usr/local/bin/ffmpeg /usr/bin/ffmpeg
+# Install dependencies and FFmpeg 7.x from Ubuntu repos
+RUN apt-get update && apt-get install -y curl bash unzip ffmpeg && rm -rf /var/lib/apt/lists/*
 
 # Install UHF server with specific version
 ARG TARGETARCH

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # UHF Server – Docker Setup
 
-[![Repo](https://img.shields.io/badge/repo-1.2.5-purple.svg)](CHANGELOG.md)
+[![Repo](https://img.shields.io/badge/repo-1.2.6-purple.svg)](CHANGELOG.md)
 [![UHF Server](https://img.shields.io/badge/uhf_server-1.2.0-orange.svg)](https://github.com/swapplications/uhf-server-dist)
-[![FFmpeg](https://img.shields.io/badge/ffmpeg-7.0.2-green.svg)](https://ffmpeg.org/)
-[![Docker](https://img.shields.io/badge/Docker-uhf--1.2.0--ffmpeg7.0.2--d2-blue?logo=docker)](https://hub.docker.com/r/solidpixel/uhf-server/tags)
+[![FFmpeg](https://img.shields.io/badge/ffmpeg-7.1.1-green.svg)](https://ffmpeg.org/)
+[![Docker](https://img.shields.io/badge/Docker-uhf--1.2.0--ffmpeg7.1.1--d1-blue?logo=docker)](https://hub.docker.com/r/solidpixel/uhf-server/tags)
 
 Run the [UHF Recording Server](https://www.uhfapp.com/server) using Docker. No manual setup, no system-level dependencies — just `docker compose up` and visit port 8000 (or your custom port).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   uhf-server:
 
-    image: solidpixel/uhf-server:uhf-1.2.0-ffmpeg7.0.2-d2
+    image: solidpixel/uhf-server:uhf-1.2.0-ffmpeg7.1.1-d1
     container_name: uhf-server
     restart: unless-stopped
 


### PR DESCRIPTION
Fixes [Issue #16](https://github.com/solid-pixel/uhf-server-docker/issues/16)

#### Docker Compose Changes
- Update `image` tag to `solidpixel/uhf-server:uhf-1.2.0-ffmpeg7.1.1-d1`

#### Docker Image Changes
- New Docker image tag: `solidpixel/uhf-server:uhf-1.2.0-ffmpeg7.1.1-d1`
- Updated FFmpeg to standard version `7.1.1` (previously used custom build)
- Switched to `Ubuntu 25.04` (previously used `Debian Bookworm`)