### PR TITLE
chore: bump UHF server version to 1.6.0

### DIFF
--- a/.dev/versions.env
+++ b/.dev/versions.env
@@ -1,10 +1,10 @@
 # Version definitions for UHF Server Docker
 
 # Tag of this repo itself (e.g. config/scripts/compose changes)
-REPO_VERSION=1.5.1
+REPO_VERSION=1.6.0
 
 # The actual UHF version used inside the image
-UHF_VERSION=1.5.1
+UHF_VERSION=1.6.0
 
 # FFmpeg version used as base
 FFMPEG_VERSION=7.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
 <!-- Add your changes below. Most recent at the top. -->
-## Version 1.5.1 – 2025-08-23
+## Version 1.6.0 – 2026-02-18
 
-#### Changes
-- 
+#### Docker Image Changes
+- Updated `uhf-server` to version `1.6.0` ([Changelog](https://github.com/swapplications/uhf-server-dist/blob/main/CHANGELOG.md))
+
+#### Docker Compose Changes
+- Update `image` tag to `solidpixel/uhf-server:uhf-1.6.0-ffmpeg7.1.1-d1`
 
 ## Version 1.5.1 – 2025-08-23
 
@@ -13,7 +16,6 @@
 
 #### Docker Compose Changes
 - Update `image` tag to `solidpixel/uhf-server:uhf-1.5.1-ffmpeg7.1.1-d1`
-
 
 ## Version 1.4.0 – 2025-06-07
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # UHF Server – Docker Setup
 
-[![Repo](https://img.shields.io/badge/repo-1.5.1-purple.svg)](CHANGELOG.md)
-[![UHF Server](https://img.shields.io/badge/uhf_server-1.5.1-orange.svg)](https://github.com/swapplications/uhf-server-dist)
+[![Repo](https://img.shields.io/badge/repo-1.6.0-purple.svg)](CHANGELOG.md)
+[![UHF Server](https://img.shields.io/badge/uhf_server-1.6.0-orange.svg)](https://github.com/swapplications/uhf-server-dist)
 [![FFmpeg](https://img.shields.io/badge/ffmpeg-7.1.1-green.svg)](https://ffmpeg.org/)
-[![Docker](https://img.shields.io/badge/Docker-uhf--1.5.1--ffmpeg7.1.1--d1-blue?logo=docker)](https://hub.docker.com/r/solidpixel/uhf-server/tags)
+[![Docker](https://img.shields.io/badge/Docker-uhf--1.6.0--ffmpeg7.1.1--d1-blue?logo=docker)](https://hub.docker.com/r/solidpixel/uhf-server/tags)
 
 Run the [UHF Recording Server](https://www.uhfapp.com/server) using Docker. No manual setup, no system-level dependencies — just `docker compose up` and visit port 8000 (or your custom port).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
 
   uhf-server:
 
-    image: solidpixel/uhf-server:uhf-1.5.1-ffmpeg7.1.1-d1
+    image: solidpixel/uhf-server:uhf-1.6.0-ffmpeg7.1.1-d1
     container_name: uhf-server
     restart: unless-stopped
 


### PR DESCRIPTION
## Version 1.6.0 – 2026-02-18

#### Docker Image Changes
- Updated `uhf-server` to version `1.6.0` ([Changelog](https://github.com/swapplications/uhf-server-dist/blob/main/CHANGELOG.md))

#### Docker Compose Changes
- Update `image` tag to `solidpixel/uhf-server:uhf-1.6.0-ffmpeg7.1.1-d1`