### PR TITLE
chore: upgrade UHF server to 2.0.0

### DIFF
--- a/.dev/build-docker.sh
+++ b/.dev/build-docker.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -9,7 +12,7 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 # Load versions
-source "$(dirname "$0")/versions.env"
+source "${SCRIPT_DIR}/versions.env"
 
 # Build image tag
 if [ -n "$DOCKER_REVISION" ]; then
@@ -31,11 +34,11 @@ docker buildx build \
     --no-cache \
     --platform linux/amd64,linux/arm64 \
     --build-arg UHF_VERSION="${UHF_VERSION}" \
-    -f ./Dockerfile.uhf \
+    -f "${REPO_ROOT}/Dockerfile.uhf" \
     -t "solidpixel/uhf-server:${IMAGE_TAG}" \
     -t "solidpixel/uhf-server:latest" \
     --push \
-    ..
+    "${REPO_ROOT}"
 
 echo -e "\n${GREEN}✨ Done! Docker images:${NC}"
 echo -e "${BLUE}📦 solidpixel/uhf-server:${YELLOW}${IMAGE_TAG}${NC}"

--- a/.dev/prepare-release.sh
+++ b/.dev/prepare-release.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -9,7 +12,7 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 # Source versions
-source "$(dirname "$0")/versions.env"
+source "${SCRIPT_DIR}/versions.env"
 
 # Generate Docker image version (includes optional patch revision)
 if [ -n "$DOCKER_REVISION" ]; then
@@ -19,9 +22,9 @@ else
 fi
 
 # Path to files
-README_PATH="$(dirname "$0")/../README.md"
-COMPOSE_PATH="$(dirname "$0")/../docker-compose.yml"
-CHANGELOG_PATH="$(dirname "$0")/../CHANGELOG.md"
+README_PATH="${REPO_ROOT}/README.md"
+COMPOSE_PATH="${REPO_ROOT}/docker-compose.yml"
+CHANGELOG_PATH="${REPO_ROOT}/CHANGELOG.md"
 
 # Function to update badge
 update_badge() {
@@ -31,6 +34,12 @@ update_badge() {
     sed -i '' "s|${name}-[^-]*-${color}\.svg|${name}-${version}-${color}.svg|g" "$README_PATH"
 }
 
+# Docker badge messages escape hyphens as double hyphens for Shields.io.
+update_docker_badge() {
+    local badge_version="${DOCKER_VERSION//-/--}"
+    sed -E -i '' "s|badge/Docker-[^?]+-blue\\?logo=docker|badge/Docker-${badge_version}-blue?logo=docker|g" "$README_PATH"
+}
+
 echo -e "\n${BLUE}🚀 Preparing release ${YELLOW}${REPO_VERSION}${NC}..."
 
 # Update badges
@@ -38,6 +47,7 @@ echo -e "\n${BLUE}🎯 Updating badges...${NC}"
 update_badge "repo" "$REPO_VERSION" "purple"
 update_badge "uhf_server" "$UHF_VERSION" "orange"
 update_badge "ffmpeg" "$FFMPEG_VERSION" "green"
+update_docker_badge
 
 # Update docker-compose.yml version
 echo -e "\n${BLUE}📝 Updating docker-compose.yml...${NC}"
@@ -64,4 +74,6 @@ fi
 echo -e "\n${GREEN}✨ Done!${NC}"
 echo -e "\n${YELLOW}✅ Now open a PR and merge it.${NC}"
 echo -e "${BLUE}After merging, run:${NC}"
-echo -e "${YELLOW}./.dev/tag-release.sh${NC}\n"
+echo -e "${YELLOW}./.dev/build-docker.sh${NC}"
+echo -e "${BLUE}After the images are published and verified, run:${NC}"
+echo -e "${YELLOW}./.dev/tag-release.sh${NC} and publish the GitHub release.${NC}\n"

--- a/.dev/tag-release.sh
+++ b/.dev/tag-release.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -9,17 +12,21 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 # Source versions
-source "$(dirname "$0")/versions.env"
+source "${SCRIPT_DIR}/versions.env"
 
 # Make sure we are on main
-git checkout main
-git pull origin main
+git -C "$REPO_ROOT" checkout main
+git -C "$REPO_ROOT" pull --ff-only origin main
+
+if git -C "$REPO_ROOT" rev-parse --verify --quiet "refs/tags/${REPO_VERSION}" >/dev/null; then
+    echo -e "${RED}Tag ${REPO_VERSION} already exists. Refusing to overwrite it.${NC}"
+    exit 1
+fi
 
 # Create and push git tag
 echo -e "\n${BLUE}🏷️  Tagging version ${YELLOW}${REPO_VERSION}${NC}..."
-git tag -f "${REPO_VERSION}"
-git push -f origin "${REPO_VERSION}"
+git -C "$REPO_ROOT" tag -a "${REPO_VERSION}" -m "Release ${REPO_VERSION}"
+git -C "$REPO_ROOT" push origin "${REPO_VERSION}"
 
 echo -e "\n${GREEN}✅ Git tag ${YELLOW}${REPO_VERSION}${GREEN} created and pushed.${NC}"
-echo -e "\n${BLUE}ℹ️  Now you can build and push the Docker images by running:${NC}"
-echo -e "${YELLOW}./.dev/build-docker.sh${NC}\n"
+echo -e "\n${BLUE}ℹ️  Publish GitHub release ${YELLOW}${REPO_VERSION}${BLUE} after confirming the Docker images are online.${NC}\n"

--- a/.dev/versions.env
+++ b/.dev/versions.env
@@ -1,10 +1,10 @@
 # Version definitions for UHF Server Docker
 
 # Tag of this repo itself (e.g. config/scripts/compose changes)
-REPO_VERSION=1.6.0
+REPO_VERSION=2.0.0
 
 # The actual UHF version used inside the image
-UHF_VERSION=1.6.0
+UHF_VERSION=2.0.0
 
 # FFmpeg version used as base
 FFMPEG_VERSION=7.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
 <!-- Add your changes below. Most recent at the top. -->
+## Version 2.0.0 – 2026-08-28
+
+#### Docker Image Changes
+- Updated `uhf-server` to version `2.0.0` ([upstream release](https://github.com/swapplications/uhf-server-dist/releases/tag/2.0.0))
+- New recordings use HLS playlists and segments; legacy single-file recordings remain supported
+- Retained Ubuntu 25.04, FFmpeg 7.1.1, Comskip, and amd64/arm64 support
+
+#### Docker Compose Changes
+- Updated `image` tag to `solidpixel/uhf-server:uhf-2.0.0-ffmpeg7.1.1-d1`
+- Fixed `ENABLE_COMMERCIAL_DETECTION` so only `true` enables commercial detection; `false`, empty, and unset values leave it disabled
+- Preserved `PASSWORD` values containing spaces or shell-sensitive characters as a single argument
+
+#### Upgrade Notes
+- Back up `uhf-data` before upgrading, then pull and recreate the container while keeping the existing data mount
+
 ## Version 1.6.0 – 2026-02-18
 
 #### Docker Image Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,14 +47,16 @@ vim .dev/versions.env
 # 4. Build and push Docker images (must be done before tagging)
 ./.dev/build-docker.sh
 
-# 5. After images are online, create and push the Git tag
+# 5. After images are online and verified, create and push the Git tag
 ./.dev/tag-release.sh
+
+# 6. Publish the matching GitHub release
 ```
 
 The scripts handle different parts of the release process:
 - `prepare-release.sh` updates documentation, badges, docker-compose.yml, and adds a changelog entry
 - `build-docker.sh` builds and pushes multi-arch Docker images (before tagging)
-- `tag-release.sh` creates and pushes the Git tag (after Docker images are online)
+- `tag-release.sh` creates and pushes the Git tag (after Docker images are online and verified); publish the GitHub release from that tag
 
 Docker images are pushed with these tags:
 - `solidpixel/uhf-server:latest`

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # UHF Server – Docker Setup
 
-[![Repo](https://img.shields.io/badge/repo-1.6.0-purple.svg)](CHANGELOG.md)
-[![UHF Server](https://img.shields.io/badge/uhf_server-1.6.0-orange.svg)](https://github.com/swapplications/uhf-server-dist)
+[![Repo](https://img.shields.io/badge/repo-2.0.0-purple.svg)](CHANGELOG.md)
+[![UHF Server](https://img.shields.io/badge/uhf_server-2.0.0-orange.svg)](https://github.com/swapplications/uhf-server-dist)
 [![FFmpeg](https://img.shields.io/badge/ffmpeg-7.1.1-green.svg)](https://ffmpeg.org/)
-[![Docker](https://img.shields.io/badge/Docker-uhf--1.6.0--ffmpeg7.1.1--d1-blue?logo=docker)](https://hub.docker.com/r/solidpixel/uhf-server/tags)
+[![Docker](https://img.shields.io/badge/Docker-uhf--2.0.0--ffmpeg7.1.1--d1-blue?logo=docker)](https://hub.docker.com/r/solidpixel/uhf-server/tags)
 
 Run the [UHF Recording Server](https://www.uhfapp.com/server) using Docker. No manual setup, no system-level dependencies — just `docker compose up` and visit port 8000 (or your custom port).
 
@@ -14,6 +14,7 @@ Run the [UHF Recording Server](https://www.uhfapp.com/server) using Docker. No m
 - ✨ [Features](#-features)
 - 📋 [Requirements](#-requirements)
 - 🚀 [Getting Started](#-getting-started)
+- ⬆️ [Upgrading to 2.0.0](#upgrading-to-200)
 - ⚙️ [Customization](#️-customization)
 - 🖥️ [Running on Unraid](#️-running-on-unraid-and-truenas-scale)
 - 👥 [Credits](#-credits)
@@ -74,6 +75,17 @@ This Docker wrapper is _not officially developed or maintained_ by Swapplication
     - SERVER ADDRESS: `<your-host-ip>`
     - SERVER PORT: `8000` (or the port you set up in `docker-compose.yml`)
 
+## Upgrading to 2.0.0
+
+UHF Server 2 records new programs as HLS playlists and segments. Existing legacy single-file recordings remain supported.
+
+Before upgrading, back up the complete `uhf-data` directory. Then pull or recreate the container so Compose uses `solidpixel/uhf-server:uhf-2.0.0-ffmpeg7.1.1-d1` while retaining the existing `./uhf-data:/var/lib/uhf-server` mount:
+
+```bash
+docker compose pull
+docker compose up -d --force-recreate
+```
+
 
 
 ---
@@ -86,10 +98,10 @@ The following environment variables can be configured in `docker-compose.yml`:
 - **RECORDINGS_DIR**: Location for recordings (default: `/var/lib/uhf-server/recordings`)
 - **DB_PATH**: Path to database file (default: `/var/lib/uhf-server/db.json`)
 - **LOG_LEVEL**: Logging verbosity (default: `INFO`) - (DEBUG, INFO, WARNING, ERROR, CRITICAL)
-- **ENABLE_COMMERCIAL_DETECTION**: Enable automatic commercial detection after recordings (default: `false`) — uses [`comskip`](https://github.com/erikkaashoek/Comskip), already installed in this image
-- **PASSWORD**: (optional) Passes `--password $PASSWORD` to `uhf-server` if set
+- **ENABLE_COMMERCIAL_DETECTION**: Set exactly `true` to enable automatic commercial detection after recordings. `false`, an empty value, or an unset variable leaves it disabled (default: `false`). Uses [`comskip`](https://github.com/erikkaashoek/Comskip), already installed in this image
+- **PASSWORD**: (optional) Passes the complete value as one `--password` argument to `uhf-server`, including values containing spaces or shell-sensitive characters
 
-You can set these variables in three ways:
+`ENABLE_COMMERCIAL_DETECTION` and `PASSWORD` are passed through by Compose and can be set in three ways. For the other optional variables, first uncomment their entries in `docker-compose.yml`:
 1. Directly in the `docker-compose.yml` file (uncomment the environment section)
 2. In a `.env` file placed in the same directory as your `docker-compose.yml`
 3. As environment variables in your shell before running `docker compose up`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
 
   uhf-server:
 
-    image: solidpixel/uhf-server:uhf-1.6.0-ffmpeg7.1.1-d1
+    image: solidpixel/uhf-server:uhf-2.0.0-ffmpeg7.1.1-d1
     container_name: uhf-server
     restart: unless-stopped
 
@@ -20,9 +20,9 @@ services:
 
     # Optional container environment config
     environment:
-      - ENABLE_COMMERCIAL_DETECTION=false  # set true for commercial detection
+      - ENABLE_COMMERCIAL_DETECTION=${ENABLE_COMMERCIAL_DETECTION:-false}  # set true for commercial detection
+      - PASSWORD=${PASSWORD:-}
       # Uncomment below to customize internal container settings (usually not needed)
-      # - PASSWORD=your_password_here
       # - API_HOST=0.0.0.0
       # - API_PORT=8000
       # - RECORDINGS_DIR=/var/lib/uhf-server/recordings
@@ -32,12 +32,20 @@ services:
     # Command with conditional flags
     # !!! Do not modify this unless you know what you're doing !!!
     command:
-      - sh
+      - bash
       - -c
       - |
-          exec uhf-server \
-            $${ENABLE_COMMERCIAL_DETECTION:+--enable-commercial-detection} \
-            $${PASSWORD:+--password "$$PASSWORD"}
+          commercial_detection="$${ENABLE_COMMERCIAL_DETECTION:-}"
+          password="$${PASSWORD:-}"
+          unset ENABLE_COMMERCIAL_DETECTION PASSWORD
+          args=(uhf-server)
+          if [[ "$$commercial_detection" == "true" ]]; then
+            args+=(--enable-commercial-detection)
+          fi
+          if [[ -n "$$password" ]]; then
+            args+=(--password "$$password")
+          fi
+          exec "$${args[@]}"
 
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/server/stats"] # update URL if API_PORT changes


### PR DESCRIPTION
## Summary

- upgrade the wrapper and Compose image to UHF Server 2.0.0
- fix commercial-detection boolean handling and preserve passwords as one CLI argument
- document the HLS recording migration and data-backup/recreate steps
- repair release scripts so they resolve the repository root, use the correct Docker build context, and follow prepare → PR merge → build/push → tag/release

Addresses #35. The issue will remain open until the multi-architecture Docker images, published runtime smoke test, tag, and GitHub release have all been verified.

## Verification

- `bash -n` for all release scripts
- `docker compose config`
- exact and byte-idempotent temporary-copy release preparation, including all four badges, Compose tag, and one changelog entry
- build script invoked outside the repository with mocked Docker, confirming the repository itself is the build context
- clean arm64 and emulated amd64 builds
- both architectures: `uhf-server --help`, FFmpeg 7.1.1, Comskip 0.83.001, and `/server/stats` reporting UHF 2.0.0
- Compose runtime matrix: unset/false/empty disable commercial detection; exact true enables it; shell-sensitive password stays one argument and health remains good
- deterministic DVR API test: recorded a local MPEG-TS source to HLS, served the playlist and segment, then recreated the container with the same mount and confirmed database, metadata, playlist, and four segments persisted