### PR TITLE
docs: expand 2.0 upgrade instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,13 @@
 - Preserved `PASSWORD` values containing spaces or shell-sensitive characters as a single argument
 
 #### Upgrade Notes
-- Back up `uhf-data` before upgrading, then pull and recreate the container while keeping the existing data mount
+- Back up the complete `uhf-data` directory before upgrading.
+- Pull and recreate the container while retaining the existing `./uhf-data:/var/lib/uhf-server` mount:
+
+```bash
+docker compose pull
+docker compose up -d --force-recreate
+```
 
 ## Version 1.6.0 – 2026-02-18
 


### PR DESCRIPTION
## Summary

- add the complete 2.0 backup and upgrade instructions to the changelog
- show the exact `docker compose pull` and recreate commands
- explicitly retain the existing `./uhf-data:/var/lib/uhf-server` mount

This follows up the published 2.0.0 release documentation.